### PR TITLE
Fix templates fail to load on concurrent requests

### DIFF
--- a/src/Haqua.Scriban.Web/Program.cs
+++ b/src/Haqua.Scriban.Web/Program.cs
@@ -6,6 +6,8 @@ builder.Services.AddScribanTemplate();
 
 var app = builder.Build();
 
+await app.UseScribanTemplateAsync();
+
 app.UseStaticFiles();
 
 app.MapGet("/", () => Results.Extensions.ScribanView("pages/home.html", new { Name = "Scriban Template" }));

--- a/src/Haqua.Scriban/Haqua.Scriban.csproj
+++ b/src/Haqua.Scriban/Haqua.Scriban.csproj
@@ -7,16 +7,16 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Scriban" Version="5.4.4"/>
-        <PackageReference Include="WebMarkupMin.Core" Version="2.9.0"/>
+        <PackageReference Include="Scriban" Version="5.4.4" />
+        <PackageReference Include="WebMarkupMin.Core" Version="2.9.0" />
     </ItemGroup>
 
     <ItemGroup>
-        <None Remove="Haqua.Scriban.csproj.DotSettings"/>
+        <None Remove="Haqua.Scriban.csproj.DotSettings" />
     </ItemGroup>
 
 </Project>

--- a/src/Haqua.Scriban/ScribanHostExtensions.cs
+++ b/src/Haqua.Scriban/ScribanHostExtensions.cs
@@ -1,0 +1,24 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Haqua.Scriban;
+
+public static class ScribanHostExtensions
+{
+    /// <summary>
+    /// Load scriban template.
+    /// </summary>
+    /// <exception cref="NullReferenceException"></exception>
+    /// <returns>The same instance of the <see cref="IHost" /> for chaining.</returns>
+    public static async Task<IHost> UseScribanTemplateAsync(this IHost host)
+    {
+        var scribanService = host.Services.GetService<ScribanTemplate>();
+        if (scribanService == null)
+        {
+            throw new NullReferenceException(nameof(ScribanTemplate));
+        }
+
+        await scribanService.LoadTemplateFromDirectoryAsync().ConfigureAwait(false);
+        return host;
+    }
+}

--- a/src/Haqua.Scriban/ScribanTemplate.cs
+++ b/src/Haqua.Scriban/ScribanTemplate.cs
@@ -27,13 +27,12 @@ public class ScribanTemplate
         }
     }
 
-    public async Task<string> RenderAsync(string viewPath, object? model = null)
+    /// <summary>
+    /// Render template from specified viewPath.
+    /// </summary>
+    /// <returns>Rendered template</returns>
+    public ValueTask<string> RenderAsync(string viewPath, object? model = null)
     {
-        if (_templates.Count == 0)
-        {
-            await LoadTemplateFromDirectoryAsync().ConfigureAwait(false);
-        }
-
         var scriptObject = new ScriptObject { ["model"] = model };
 
         var context = new TemplateContext { TemplateLoader = _templateLoader };
@@ -44,11 +43,10 @@ public class ScribanTemplate
             context.CachedTemplates.Add(template.Key, template.Value);
         }
 
-        var result = await _templates[viewPath].RenderAsync(context).ConfigureAwait(false);
-        return result;
+        return _templates[viewPath].RenderAsync(context);
     }
 
-    private async Task LoadTemplateFromDirectoryAsync()
+    internal async Task LoadTemplateFromDirectoryAsync()
     {
         if (!_options.FileProvider!.GetDirectoryContents(Views).Exists)
         {

--- a/src/Haqua.Scriban/ScribanTemplateServiceCollectionExtensions.cs
+++ b/src/Haqua.Scriban/ScribanTemplateServiceCollectionExtensions.cs
@@ -6,25 +6,30 @@ namespace Haqua.Scriban;
 
 public static class ScribanTemplateServiceCollectionExtensions
 {
+    /// <summary>
+    /// Adds scriban template service to the specified <see cref="IServiceCollection" />.
+    /// </summary>
+    /// <returns>The same instance of the <see cref="IServiceCollection" /> for chaining.</returns>
     public static IServiceCollection AddScribanTemplate(
         this IServiceCollection services,
         ScribanTemplateOptions? options = null)
     {
         services.TryAddSingleton(provider =>
         {
-            if (options?.FileProvider == null)
+            if (options?.FileProvider != null)
             {
-                var webHostEnv = provider.GetService<IWebHostEnvironment>();
-                var fileProvider = webHostEnv!.ContentRootFileProvider;
-
-                if (options == null)
-                {
-                    return new ScribanTemplate(new ScribanTemplateOptions { FileProvider = fileProvider });
-                }
-
-                options.FileProvider = fileProvider;
+                return new ScribanTemplate(options);
             }
 
+            var webHostEnv = provider.GetService<IWebHostEnvironment>();
+            var fileProvider = webHostEnv!.ContentRootFileProvider;
+
+            if (options == null)
+            {
+                return new ScribanTemplate(new ScribanTemplateOptions { FileProvider = fileProvider });
+            }
+
+            options.FileProvider = fileProvider;
             return new ScribanTemplate(options);
         });
 


### PR DESCRIPTION
Current logic for loading templates is on `ScribanTemplate.RenderAsync` by checking if `ScribanTemplate._templates` is empty or not. By doing this, the template will fail to load on concurrent requests after the app running.

```
fail: Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddleware[1]
      An unhandled exception has occurred while executing the request.
      System.InvalidOperationException: Operations that change non-concurrent collections must have exclusive a
ccess. A concurrent update was performed on this collection and corrupted its state. The collection's state is
no longer correct.
```